### PR TITLE
 * handle special characters in arguments

### DIFF
--- a/runcached.py
+++ b/runcached.py
@@ -23,6 +23,7 @@ import random
 import atexit
 import syslog
 import tempfile
+import shlex
 
 
 argskip=1
@@ -34,7 +35,7 @@ if sys.argv[1] == '-c':
 	cacheperiod=int(sys.argv[2])
 	argskip=3
 
-cmd=" ".join(sys.argv[argskip:])
+cmd=shlex.join(sys.argv[argskip:])
 
 #hash of executed command w/args
 m = hashlib.md5()


### PR DESCRIPTION
The way it is now, runcached will run the command with only one argument `my-command "1 2 3"` as `my-command 1 2 3` (with three arguments).  This change fixes that.